### PR TITLE
Fix #5: Add workspace volume persistence to Docker setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Always use Docker in a tmux pane:
 ```bash
 docker build -t markus-test .
 docker volume create markus-claude-config
-tmux split-window -h "docker run --rm -it --cap-add NET_ADMIN --cap-add NET_RAW -v markus-claude-config:/home/node/.claude markus-test"
+tmux split-window -h "docker run --rm -it --cap-add NET_ADMIN --cap-add NET_RAW -v markus-claude-config:/home/node/.claude -v markus-workspace:/workspace markus-test"
 ```
 
 First run requires `/login` inside the container. Credentials persist in the volume.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ RUN cd /plugin && bun install --frozen-lockfile && chown -R node:node /plugin /w
 
 USER node
 VOLUME /home/node/.claude
+VOLUME /workspace
 
 ENTRYPOINT ["sh", "-c", "sudo init-firewall.sh && exec claude --dangerously-skip-permissions --plugin-dir /plugin --dangerously-load-development-channels plugin:markus@inline"]


### PR DESCRIPTION
## Summary
- Add `VOLUME /workspace` to the Dockerfile alongside the existing `VOLUME /home/node/.claude` so Docker always creates a volume for workspace data
- Update the `docker run` command in CLAUDE.md to include `-v markus-workspace:/workspace`, matching what the test plan already documents

Closes #5

## Test plan
- [ ] Build image: `docker build -t markus-test .`
- [ ] Run container with the updated command from CLAUDE.md (includes `-v markus-workspace:/workspace`)
- [ ] Bootstrap workspace, create memory entries, then exit
- [ ] Re-run container with the same volumes -- verify SOUL.md, USER.md, MEMORY.md, memory/ all persist