### PR TITLE
Add Claude agent worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# claude agent worktrees
+.claude/worktrees/
+
 # dependencies (bun install)
 node_modules
 


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude Claude agent worktree directories from version control.

## Changes
- Added `.claude/worktrees/` directory to `.gitignore` to prevent Claude agent worktree files from being tracked in the repository

## Details
This change ensures that temporary or generated worktree files created by Claude agents are not accidentally committed to the repository, keeping the codebase clean and focused on source code only.

https://claude.ai/code/session_01WKU2DVuhbFKeSiqedETSbP